### PR TITLE
fix: require is not defined in ES module scope in `bin/cli`

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require('../cli');
+import '../cli.js';


### PR DESCRIPTION
Running `qsp-cli` 1.0.3v throw exception:

```
file:///J:/nodejs/node-v18.20.0-win-x64/node_modules/@qsp/cli/bin/run:3
require('../cli');
^

ReferenceError: require is not defined in ES module scope, you can use import instead
    at file:///J:/nodejs/node-v18.20.0-win-x64/node_modules/@qsp/cli/bin/run:3:1
    at ModuleJob.run (node:internal/modules/esm/module_job:195:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:337:24)
    at async loadESM (node:internal/process/esm_loader:34:7)
    at async handleMainPromise (node:internal/modules/run_main:106:12)

Node.js v18.20.0
```